### PR TITLE
Better CAMI support

### DIFF
--- a/lua/permaprops/sv_menu.lua
+++ b/lua/permaprops/sv_menu.lua
@@ -55,7 +55,9 @@ local function PermissionLoad()
 	end
 
 end
-PermissionLoad()
+
+hook.Add("Initialize", "PermaPropPermLoad", PermissionLoad)
+hook.Add("CAMI.OnUsergroupRegistered", "PermaPropPermLoadCAMI", PermissionLoad) -- In case something changes
 
 local function PermissionSave()
 


### PR DESCRIPTION
Be sure that most admin systems (using CAMI) are supported by actually using CAMI to update/loading usergroups  and also load the Initial usergroups only on Initialize to give Addons some time to register them on startup